### PR TITLE
perf: avoid using refs for simple pushes

### DIFF
--- a/Sources/Example/LuaNSAlert.swift
+++ b/Sources/Example/LuaNSAlert.swift
@@ -111,8 +111,7 @@ public enum LuaNSAlert {
             return alert.runModal()
         }
 
-        let number = LuaNumber.create(Int32(result.rawValue), in: state)
-        number.push(to: state)
+        Int32(result.rawValue).push(to: state)
         return 1
     }
 

--- a/Sources/SwiftLuau/Abstract/LuaPushable.swift
+++ b/Sources/SwiftLuau/Abstract/LuaPushable.swift
@@ -1,3 +1,5 @@
+import SwiftLuauBindings
+
 public protocol LuaPushable {
     /// Push the value onto the given Lua state.
     /// - Parameter state: The Lua state to push the value onto.
@@ -6,30 +8,31 @@ public protocol LuaPushable {
 
 extension String: LuaPushable {
     public func push(to state: LuaState) {
-        LuaString.create(self, in: state).push(to: state)
+        let bytes = [UInt8](self.utf8)
+        lua_pushlstring(state.state, bytes, bytes.count)
     }
 }
 
 extension Int32: LuaPushable {
     public func push(to state: LuaState) {
-        LuaNumber.create(self, in: state).push(to: state)
+        lua_pushinteger(state.state, self)
     }
 }
 
-extension Int: LuaPushable {
+extension UInt32: LuaPushable {
     public func push(to state: LuaState) {
-        LuaNumber.create(Int32(self), in: state).push(to: state)
+        lua_pushunsigned(state.state, self)
     }
 }
 
 extension Double: LuaPushable {
     public func push(to state: LuaState) {
-        LuaNumber.create(self, in: state).push(to: state)
+        lua_pushnumber(state.state, self)
     }
 }
 
 extension Bool: LuaPushable {
     public func push(to state: LuaState) {
-        LuaBoolean.create(self, in: state).push(to: state)
+        lua_pushboolean(state.state, self ? 1 : 0)
     }
 }


### PR DESCRIPTION
This pull request refactors how Swift types are pushed onto the Lua stack by updating the `LuaPushable` protocol extensions to use direct Lua C API calls instead of wrapper helper types. It also introduces support for pushing `UInt32` values. These changes improve performance and simplify the code.

**Refactoring of Lua value pushing:**

* Updated `LuaPushable` protocol extensions for `String`, `Int32`, `Double`, and `Bool` to use direct Lua C API functions (e.g., `lua_pushlstring`, `lua_pushinteger`, `lua_pushnumber`, `lua_pushboolean`) instead of helper wrapper types like `LuaString`, `LuaNumber`, and `LuaBoolean`.
* Added support for pushing `UInt32` values to Lua using `lua_pushunsigned`.

**Other improvements:**

* Added `import SwiftLuauBindings` to `LuaPushable.swift` to access the Lua C API functions.
* Updated `LuaNSAlert` to use the new direct push method for `Int32` results.