### PR TITLE
fix: remove unsafe build flags so consumers can use the package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,6 @@ let cppFlags: [CXXSetting] = [
     .headerSearchPath("../VM/include"),
 
     // C++ standard
-    .unsafeFlags(["-std=c++17"]),
     .define("LUA_USE_LONGJMP", to: "1"),
     .define("LUA_API", to: "extern \"C\""),
     .define("LUACODE_API", to: "extern \"C\""),
@@ -102,5 +101,6 @@ let package = Package(
                 .copy("Resources/luaApp.luau")
             ]
         ),
-    ]
+    ],
+    cxxLanguageStandard: .cxx17
 )

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ dependencies: [
 ## Usage
 
 ```swift
-import SwiftLuau
+import Luau
 
 guard let state = LuaState.create() else {
     fatalError("Failed to create Luau state")


### PR DESCRIPTION
This pull request makes some configuration improvements and documentation updates for the package. The main changes are updating the way the C++17 standard is specified for the build and correcting the import statement in the usage example.

Build configuration improvements:
* Set the C++ language standard to C++17 using the `cxxLanguageStandard` property in `Package.swift` instead of the previous `unsafeFlags` approach. This is a safer and more idiomatic way to specify the C++ standard in Swift Package Manager. [[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL18) [[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eL105-R105)

Documentation update:
* Updated the usage example in `README.md` to use the correct module name `Luau` instead of `SwiftLuau` in the import statement.