### PR TITLE
fix: update package name to SwiftLuau and correct version in README

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let cppFlags: [CXXSetting] = [
 ]
 
 let package = Package(
-    name: "Luau",
+    name: "SwiftLuau",
     platforms: [
         .macOS(.v12),
         .macCatalyst(.v13),
@@ -35,8 +35,7 @@ let package = Package(
         .library(
             name: "Luau",
             targets: ["Luau"]
-        ),
-        .executable(name: "Example", targets: ["Example"]),
+        )
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add the following to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/RadiusDay/SwiftLuau.git", from: "0.2.0")
+    .package(url: "https://github.com/RadiusDay/SwiftLuau.git", from: "0.3.1")
 ]
 ```
 
@@ -44,7 +44,7 @@ guard let bytecode = LuaBytecode.compile(source: source) else {
 let loadResult = state.load(chunkName: "=source.luau", bytecode: bytecode)
 guard case .success = loadResult else {
     if case let .failure(error) = loadResult {
-        fatalError("Failed to load lua app: \(error ?? "unknown error")")
+        fatalError("Failed to load lua app: \(error.message ?? "unknown error")")
     } else {
         fatalError("Failed to load lua app: unknown error")
     }
@@ -55,7 +55,7 @@ let function = LuaFunction(reference: ref)
 let callResult = function.protectedCall(arguments: [], nresults: 1)
 guard case .success = callResult else {
     if case let .failure(error) = callResult {
-        fatalError("Failed to run lua app: \(error ?? "unknown error")")
+        fatalError("Failed to run lua app: \(error.message ?? "unknown error")")
     } else {
         fatalError("Failed to run lua app: unknown error")
     }


### PR DESCRIPTION
This pull request makes several updates to the package configuration and documentation for the project. The most significant changes are the renaming of the package, updates to the example code error handling, and an updated dependency version in the README.

**Package configuration changes:**

* Renamed the package from `Luau` to `SwiftLuau` in `Package.swift` to better reflect its Swift integration.
* Removed the `Example` executable target from the package products, leaving only the library product.

**Documentation and example updates:**

* Updated the dependency version in the `README.md` from `0.2.0` to `0.3.1` to reflect the latest release.
* Improved error handling in the example code in `README.md` by accessing `error.message` instead of the error object directly in `fatalError` calls, providing clearer error messages. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R47) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L58-R58)