### PR TITLE
feat: add from methods for `LuaBytecode` and rename methods to be mor…

### DIFF
--- a/Sources/Luau/LuaBytecode.swift
+++ b/Sources/Luau/LuaBytecode.swift
@@ -26,6 +26,25 @@ public final class LuaBytecode {
         data.deallocate()
     }
 
+    /// Create a LuaBytecode from a byte array.
+    /// - Parameter bytes: The byte array to create the LuaBytecode from.
+    /// - Returns: A LuaBytecode.
+    public static func from(bytes: [UInt8]) -> LuaBytecode {
+        let data = UnsafeMutablePointer<UInt8>.allocate(capacity: bytes.count)
+        data.initialize(from: bytes, count: bytes.count)
+        return LuaBytecode(size: bytes.count, data: data)
+    }
+
+    #if canImport(Foundation)
+    /// Create a LuaBytecode from Data.
+    /// - Parameter data: The Data to create the LuaBytecode from.
+    /// - Returns: A LuaBytecode.
+    public static func from(data: Data) -> LuaBytecode {
+        let byteArray = [UInt8](data)
+        return LuaBytecode.from(bytes: byteArray)
+    }
+    #endif
+
     /// Compile Lua source code into bytecode.
     /// - Parameter source: The Lua source code to compile.
     /// - Returns: A LuaBytecode if compilation was successful, nil otherwise.
@@ -53,7 +72,7 @@ public final class LuaBytecode {
     }
 
     /// Get the bytecode as a byte array.
-    public func toData() -> [UInt8] {
+    public func toBytes() -> [UInt8] {
         return .init(UnsafeBufferPointer(start: data, count: size))
     }
 

--- a/Sources/Luau/Types/LuaBuffer.swift
+++ b/Sources/Luau/Types/LuaBuffer.swift
@@ -71,7 +71,7 @@ public struct LuaBuffer: LuaPushable, LuaGettable {
 
     /// Get the byte array of a Lua buffer.
     /// - Returns: The byte array if it exists and is a buffer, nil otherwise.
-    public func toBuffer() -> [UInt8]? {
+    public func toBytes() -> [UInt8]? {
         push(to: reference.state)
         var size: size_t = 0
         guard let ptr = lua_tobuffer(reference.state.state, -1, &size) else {


### PR DESCRIPTION
This pull request introduces improvements to the `LuaBytecode` and `LuaBuffer` APIs, focusing on more consistent naming and additional convenience methods for creating and accessing bytecode data. The main changes are grouped into new creation methods and naming consistency updates.

### New creation methods for `LuaBytecode`:
* Added a static method `from(bytes:)` to create a `LuaBytecode` instance from a byte array, improving usability when working with raw bytecode.
* Added a static method `from(data:)` (available when Foundation is imported) to create a `LuaBytecode` from a `Data` object, streamlining interoperability with Foundation types.

### Naming consistency updates:
* Renamed the method `toData()` in `LuaBytecode` to `toBytes()` for clearer intent and consistency with other APIs.
* Renamed the method `toBuffer()` in `LuaBuffer` to `toBytes()` to standardize naming across types that handle byte arrays.…e consistent