### PR TITLE
refactor(example): use require in the example instead of exposing globals

### DIFF
--- a/Sources/Example/main.swift
+++ b/Sources/Example/main.swift
@@ -47,6 +47,31 @@ private func lua_print(_ state: OpaquePointer?) -> Int32 {
     return 0
 }
 
+private func lua_require(_ state: OpaquePointer?) -> Int32 {
+    guard let state = LuaState.from(optional: state) else { return 0 }
+
+    let args = LuaValue.parseArgs(from: state, count: 1)
+    let moduleName = args[0].toString()
+
+    switch moduleName {
+    case "swiftLuau.example":
+        let table = LuaTable.create(in: state)
+        table.set(
+            key: "getPlatform",
+            to: LuaFunction.create(
+                debugName: "example.getPlatform",
+                function: lua_getPlatform,
+                in: state
+            )
+        )
+        table.setReadOnly(true)
+        table.push(to: state)
+        return 1
+    default:
+        Lua.error(state, data: "Module '\(moduleName)' not found")
+    }
+}
+
 func main() {
     guard let state = LuaState.create() else {
         print("Failed to create Lua state")
@@ -54,8 +79,8 @@ func main() {
     }
 
     state.setGlobal(
-        key: "getPlatform",
-        to: LuaFunction.create(debugName: "getPlatform", function: lua_getPlatform, in: state)
+        key: "require",
+        to: LuaFunction.create(debugName: "require", function: lua_require, in: state)
     )
     state.setGlobal(
         key: "print",
@@ -65,7 +90,18 @@ func main() {
 
     // Load lua app from resources
     let luaAppSource = """
-        print(`Hello from Luau on {getPlatform()}`)
+        local example = require("swiftLuau.example")
+
+        print(`Hello from Luau on {example.getPlatform()}`)
+
+        local status, err = pcall(function()
+            example.test = 123
+        end)
+        if status then
+            print("Modified read-only table successfully, which is unexpected")
+        else
+            print("Task failed successfully: " .. err)
+        end
 
         local function factorial(n)
             if n == 0 then

--- a/Sources/Luau/Types/LuaTable.swift
+++ b/Sources/Luau/Types/LuaTable.swift
@@ -39,6 +39,23 @@ public struct LuaTable: LuaPushable, LuaGettable {
         return LuaTable(reference: ref)
     }
 
+    /// Check if the table is read-only.
+    /// - Returns: True if the table is read-only, false otherwise.
+    public func isReadOnly() -> Bool {
+        push(to: reference.state)
+        let isReadOnly = lua_getreadonly(reference.state.state, -1) != 0
+        Lua.pop(reference.state, 1)
+        return isReadOnly
+    }
+
+    /// Make the table read-only or writable.
+    /// - Parameter readOnly: True to make the table read-only, false to make it writable.
+    public func setReadOnly(_ readOnly: Bool) {
+        push(to: reference.state)
+        lua_setreadonly(reference.state.state, -1, readOnly ? 1 : 0)
+        Lua.pop(reference.state, 1)
+    }
+
     /// Set a meta table for the Lua table.
     /// - Parameters:
     ///   - metaTable: The meta table to set.


### PR DESCRIPTION
This pull request adds support for read-only Lua tables and introduces a module system to the Swift-Luau example. The main changes include implementing the ability to mark Lua tables as read-only, updating the example to demonstrate module usage and read-only enforcement, and adding a custom `require` function to load modules.

**Module system and API changes:**

* Added a custom `lua_require` function in `main.swift` to support loading modules, specifically providing the `"swiftLuau.example"` module with a read-only table containing the `getPlatform` function. (`[Sources/Example/main.swiftR50-R80](diffhunk://#diff-aab73f7c55c34d514bddc9fc08ae2823e0f7660fbfddc48ae21f96da960fcef5R50-R80)`)
* Replaced direct global access to `getPlatform` with module-based access (`example.getPlatform`) in the Lua app source, and updated the Lua script to use the new `require` function. (`[Sources/Example/main.swiftL68-R101](diffhunk://#diff-aab73f7c55c34d514bddc9fc08ae2823e0f7660fbfddc48ae21f96da960fcef5L68-R101)`)

**Read-only table support:**

* Implemented `isReadOnly()` and `setReadOnly(_:)` methods in `LuaTable.swift` to allow checking and setting the read-only state of Lua tables from Swift. (`[Sources/Luau/Types/LuaTable.swiftR42-R58](diffhunk://#diff-f4b56a2e635993d06a3490954ed69feb63136e8cb699e5ce37398c28b6922f71R42-R58)`)
* Updated the example Lua script to demonstrate enforcement of read-only tables by attempting (and failing) to modify the module's table, with error handling and messaging. (`[Sources/Example/main.swiftL68-R101](diffhunk://#diff-aab73f7c55c34d514bddc9fc08ae2823e0f7660fbfddc48ae21f96da960fcef5L68-R101)`)